### PR TITLE
INC Order fixes and basic test

### DIFF
--- a/corpus/nodhfiles/lib/Test/App/Schema.pm
+++ b/corpus/nodhfiles/lib/Test/App/Schema.pm
@@ -1,0 +1,11 @@
+package    # NO PAUSE
+  Test::App::Schema;
+
+use strict;
+use warnings;
+
+sub schema_version {
+  1
+}
+
+1;

--- a/cpanfile
+++ b/cpanfile
@@ -4,3 +4,4 @@ requires "File::ShareDir";
 requires "namespace::autoclean";
 requires "File::pushd";
 requires "Class::Load";
+requires "Path::Tiny";

--- a/lib/Dist/Zilla/Plugin/CheckDeploymentHandlerFiles.pm
+++ b/lib/Dist/Zilla/Plugin/CheckDeploymentHandlerFiles.pm
@@ -10,6 +10,7 @@ use namespace::autoclean;
 use File::ShareDir 'module_dir';
 use File::pushd;
 use Class::Load 'load_class';
+use Path::Tiny 'path';
 
 with 'Dist::Zilla::Role::BeforeRelease';
 
@@ -50,13 +51,16 @@ around schema_module => sub {
 
 sub before_release {
     my $self = shift;
+
+    my $libdir = path($self->zilla->built_in, 'lib')->absolute;
+    require lib;
+    lib->import("$libdir");
+
     my $version = $self->schema_module->schema_version || $self->schema_module->version;
     my $previous = $version - 1;
 
     # Make sure we're working in context of the build dir.
     $self->zilla->ensure_built;
-    my $chdir = pushd($self->zilla->built_in);
-    unshift @INC, $chdir . '/lib';
 
     my $script_dir = $self->script_directory . "/PostgreSQL/upgrade/$previous-$version";
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,0 +1,54 @@
+use v5.20;
+use strict;
+use warnings;
+use Test::More;
+use Test::DZil;
+use File::pushd qw(pushd);
+use Path::Tiny qw(path);
+
+my $tzil = Builder->from_config(
+    { dist_root => 'corpus/nodhfiles' },
+    {
+        add_files => {
+            'source/dist.ini' => simple_ini(
+                {
+                    name => 'Test-App-Schema',
+                },
+                [ 'GatherDir' => { include_dotfiles => 1 } ],
+                'FakeRelease',
+                [
+                    'CheckDeploymentHandlerFiles' => {
+                        schema_module => 'Test::App::Schema'
+                    }
+                ]
+            ),
+        }
+    }
+);
+
+my $err;
+ok(
+    !do {
+        local $@ = '';
+        eval { $tzil->build };
+        $err = $@;
+    },
+    "build OK"
+) or diag explain $err;
+
+ok(
+    do {
+        local $@ = '';
+        eval { $tzil->release };
+        $err = $@;
+    },
+    "release threw exception"
+);
+
+like(
+    $err,
+    qr[\QTest/App/Schema/sql/PostgreSQL/upgrade/0-1\E],
+    "Error cried about a missing 0 -> 1 upgrade step"
+);
+
+done_testing;


### PR DESCRIPTION
PR Fixes the mis-ordered `@INC` loading and provides a working test
that confirms the module will cry if the schema is incomplete.

